### PR TITLE
[feature] Allow passing GraphQLSchema directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ module system it is exported as `GraphQLVoyager` global variable.
 ### Properties
 `Voyager` component accepts the following properties:
 
-+ `introspection` [`object` or function: `(query: string) => Promise`] - the server introspection response. If `function` is provided GraphQL Voyager will pass introspection query as a first function parameter. Function should return `Promise` which resolves to introspection response object.
++ `fetcher` _(optional)_ [function: `(query: string) => Promise`] - a function for fetching an introspection of your schema. GraphQL Voyager will pass an introspection query as a first function parameter. Function should return `Promise` which resolves to introspection response object.
+_This or `schema` below must be provided to GraphQL Voyager._
++ `schema` _(optional)_ [`GraphQLSchema`] - if you have access to your schema instantiated as a `GraphQLSchema`, you can pass that here instead of passing a `fetcher` function as described above.
 + `displayOptions` _(optional)_
   + `displayOptions.skipRelay` [`boolean`, default `true`] - skip relay-related entities
   + `displayOptions.skipDeprecated` [`boolean`, default `true`] - skip deprecated fields and entities that contain only deprecated fields.
@@ -84,7 +86,7 @@ folder as `voyager.min.js`.
 
       // Render <Voyager />
       GraphQLVoyager.init(document.getElementById('voyager'), {
-        introspection: introspectionProvider
+        fetcher: introspectionProvider
       })
     </script>
   </body>
@@ -113,7 +115,7 @@ function introspectionProvider(query) {
   }).then(response => response.json());
 }
 
-ReactDOM.render(<Voyager introspection={introspectionProvider} />, document.getElementById('voyager'));
+ReactDOM.render(<Voyager fetcher={introspectionProvider} />, document.getElementById('voyager'));
 ```
 
 Build for the web with [webpack](https://webpack.js.org/) ([example](./example/webpack-example)) or

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -45,7 +45,7 @@ export default class Demo extends React.Component {
 
     return (
       <MuiThemeProvider theme={theme}>
-        <GraphQLVoyager introspection={introspection}>
+        <GraphQLVoyager fetcher={introspection}>
           <GraphQLVoyager.PanelHeader>
             <div className="voyager-panel">
               <Logo />

--- a/example/index.html
+++ b/example/index.html
@@ -65,7 +65,7 @@
 
       // Render <Voyager /> into the body.
       GraphQLVoyager.init(document.getElementById('voyager'), {
-        introspection: introspectionProvider
+        fetcher: introspectionProvider
       });
     </script>
   </body>

--- a/example/webpack-example/index.jsx
+++ b/example/webpack-example/index.jsx
@@ -10,7 +10,7 @@ class Test extends React.Component {
 
   render() {
     return (
-      <Voyager introspection={this.introspectionProvider} displayOptions={{skipRelay: false, showLeafFields: true}}/>
+      <Voyager fetcher={this.introspectionProvider} displayOptions={{skipRelay: false, showLeafFields: true}}/>
     )
   }
 

--- a/src/components/Voyager.tsx
+++ b/src/components/Voyager.tsx
@@ -1,4 +1,5 @@
 import { introspectionQuery } from 'graphql/utilities';
+import { GraphQLSchema } from 'graphql';
 
 import { getSchema, extractTypeId } from '../introspection';
 import { SVGRender, getTypeGraph } from '../graph/';
@@ -42,7 +43,7 @@ function normalizeDisplayOptions(options) {
 }
 
 export interface VoyagerProps {
-  introspection: IntrospectionProvider | Object;
+  introspection: IntrospectionProvider | GraphQLSchema | Object;
   displayOptions?: VoyagerDisplayOptions;
   hideDocs?: boolean;
   hideSettings?: boolean;

--- a/src/introspection/introspection.ts
+++ b/src/introspection/introspection.ts
@@ -5,6 +5,7 @@ import {
   lexicographicSortSchema,
   IntrospectionSchema,
   IntrospectionType,
+  GraphQLSchema,
 } from 'graphql';
 import { SimplifiedIntrospection, SimplifiedIntrospectionWithIds, SimplifiedType } from './types';
 import { typeNameToId } from './utils';
@@ -138,7 +139,7 @@ function markRelayTypes(schema: SimplifiedIntrospectionWithIds): void {
         return;
       }
 
-      const edgesType = connectionType.fields.edges.type
+      const edgesType = connectionType.fields.edges.type;
       if (edgesType.kind !== 'OBJECT' || !edgesType.fields.node) {
         return;
       }
@@ -257,7 +258,8 @@ export function getSchema(
 ) {
   if (!introspection) return null;
 
-  let schema = buildClientSchema(introspection.data);
+  let schema =
+    introspection instanceof GraphQLSchema ? introspection : buildClientSchema(introspection.data);
   if (sortByAlphabet) {
     schema = lexicographicSortSchema(schema);
   }

--- a/src/introspection/introspection.ts
+++ b/src/introspection/introspection.ts
@@ -250,21 +250,17 @@ function assignTypesAndIDs(schema: SimplifiedIntrospection) {
   schema.types = _.keyBy(schema.types, 'id');
 }
 
-export function getSchema(
-  introspection: any,
+export function prepareSchema(
+  schema: GraphQLSchema,
   sortByAlphabet: boolean,
   skipRelay: boolean,
   skipDeprecated: boolean,
 ) {
-  if (!introspection) return null;
-
-  let schema =
-    introspection instanceof GraphQLSchema ? introspection : buildClientSchema(introspection.data);
   if (sortByAlphabet) {
     schema = lexicographicSortSchema(schema);
   }
 
-  introspection = introspectionFromSchema(schema, { descriptions: true });
+  let introspection = introspectionFromSchema(schema, { descriptions: true });
   let simpleSchema = simplifySchema(introspection.__schema);
 
   assignTypesAndIDs(simpleSchema);
@@ -276,4 +272,17 @@ export function getSchema(
     markDeprecated((<any>simpleSchema) as SimplifiedIntrospectionWithIds);
   }
   return simpleSchema;
+}
+
+export function getSchema(
+  introspection: any,
+  sortByAlphabet: boolean,
+  skipRelay: boolean,
+  skipDeprecated: boolean,
+) {
+  if (!introspection) return null;
+
+  let schema = buildClientSchema(introspection.data);
+
+  return prepareSchema(schema, sortByAlphabet, skipRelay, skipDeprecated);
 }

--- a/src/middleware/render-voyager-page.ts
+++ b/src/middleware/render-voyager-page.ts
@@ -63,7 +63,7 @@ export default function renderVoyagerPage(options: MiddlewareOptions) {
       }
 
       GraphQLVoyager.init(document.getElementById('voyager'), {
-        introspection: introspectionProvider,
+        fetcher: introspectionProvider,
         displayOptions: ${JSON.stringify(displayOptions)},
       })
     })


### PR DESCRIPTION
This allows passing an already instantiated `GraphQLSchema` in addition to an introspection fetcher or an actual introspection result. Use case is I've got somewhere where I already have the instantiated schema but not access to the introspection result (and not the endpoint to get it either).

Please let me know if there are any questions or anything I can clarify further.