### PR TITLE
feat: Search Schema by Description

### DIFF
--- a/src/components/doc-explorer/TypeList.tsx
+++ b/src/components/doc-explorer/TypeList.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { isMatch } from '../../utils';
+import { isMatch, isMatchDescription } from '../../utils';
 
 import './TypeList.css';
 
@@ -36,7 +36,7 @@ export default class TypeList extends React.Component<TypeListProps> {
     );
 
     function renderItem(type, className?: string) {
-      if (!isMatch(type.name, filter)) {
+      if (!isMatch(type.name, filter) && !isMatchDescription(type.description, filter)) {
         return null;
       }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,6 +5,14 @@ export var __dirname;
 export * from './dom-helpers';
 export * from './highlight';
 
+export function isMatchDescription(sourceDescription: string, searchValue: string) {
+  if (!sourceDescription || !searchValue) {
+    return true;
+  }
+
+  return sourceDescription.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1;
+}
+
 export function isMatch(sourceText: string, searchValue: string) {
   if (!searchValue) {
     return true;


### PR DESCRIPTION
When there are enough schemas, we cannot quickly find the schema we need,

In the i18n scenario, we use the description field to explain the purpose of the schema. It is easier to find the schema we need by querying the schema description

Therefore, the query schema is extended here to add support for describing queries