### PR TITLE
Remove 'init' and 'GraphQLVoyager' exports

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,2 @@
-import * as ReactDOM from 'react-dom';
-
-import { Voyager, VoyagerProps } from './components';
-
-// FIXME: remove in next breaking version
-/** @deprecated please use renderVoyagerPage **/
-export function init(element: HTMLElement, options: VoyagerProps) {
-  ReactDOM.render(<Voyager {...options} />, element);
-}
-
 export { Voyager, type VoyagerProps } from './components';
-
-// FIXME: remove in next breaking version
-export { Voyager as GraphQLVoyager };
-
 export { voyagerIntrospectionQuery } from './utils/introspection-query';


### PR DESCRIPTION
Please use 'renderVoyager' instead of 'init' and
'Voyager' instead of 'GraphQLVoyager'