### PR TITLE
Drop `react-dom` from peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,8 +61,7 @@
       },
       "peerDependencies": {
         "graphql": ">=16.5.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
+        "react": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "peerDependencies": {
     "graphql": ">=16.5.0",
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=18.0.0"
   },
   "dependencies": {
     "@emotion/react": "11.10.5",

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -1,3 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
+// All dependencies are bundled for this entry point
+
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 


### PR DESCRIPTION
It used only in `voayger.standalone.js` file and
it's bundled in this file.