### PR TITLE
fix: move ++ opertator to the front & cleanup useEffect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 /test-results
 /playwright-report
 /graphql-voyager-*.tgz
+/.idea
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@
 /test-results
 /playwright-report
 /graphql-voyager-*.tgz
-/.idea
-.DS_Store

--- a/src/components/Voyager.tsx
+++ b/src/components/Voyager.tsx
@@ -65,10 +65,17 @@ export default function Voyager(props: VoyagerProps) {
   useEffect(() => {
     // FIXME: handle rejection and also handle errors inside introspection
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    Promise.resolve(props.introspection).then(({ data }) => {
-      setIntrospectionData(data);
-      setSelected({ typeID: null, edgeID: null });
+    let isMounted = true;
+    void Promise.resolve(props.introspection).then(({ data }) => {
+      if(isMounted) {
+        setIntrospectionData(data);
+        setSelected({ typeID: null, edgeID: null });
+      }
     });
+
+    return () => {
+      isMounted = false;
+    }
   }, [props.introspection]);
 
   const schema = useMemo(

--- a/src/graph/svg-renderer.ts
+++ b/src/graph/svg-renderer.ts
@@ -56,7 +56,7 @@ export class SVGRender {
 
   _renderString(src: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const id = this._nextId++;
+      const id = ++this._nextId;
 
       this._listeners[id] = function (error, result): void {
         if (error) {


### PR DESCRIPTION
This PR fixes the SVG renderer. 

Previous the listener `id` index was being incremented by doing `id++`. However this returns the unincremented result. Meaning if `id = 0`. `id++` will return 0. The id never got incremented, causing the function to crash. 

Second bug fix is cleaning up the useEffect function in the Voyager component, this was causing errors. 