### PR TITLE
[DEMO]: all fields from an SDL are marked as deprecated

### DIFF
--- a/src/components/doc-explorer/TypeDoc.tsx
+++ b/src/components/doc-explorer/TypeDoc.tsx
@@ -147,8 +147,8 @@ export default class TypeDoc extends Component<TypeDocProps> {
             )}
           </span>
           <WrappedTypeName container={field} onTypeLink={onTypeLink} />
-          {field.deprecationReason !== null && (
-            <span className="doc-alert-text"> DEPRECATED</span>
+          {field.deprecationReason && (
+            <span className="doc-alert-text"> DEPRECATED </span>
           )}
           <Markdown
             text={field.description}


### PR DESCRIPTION
Fix #373 - as the deprecation reason might be null or non existing, the logic cannot show the `DEPRECATED` label for any field where the deprecation reason is just not `null`.

It can be tested with [this schema](https://gist.github.com/LunaticMuch/b0910195dbbbdf39fbf5df3af70425a6). Only the two deprecated fields are shown as deprecated.

<img width="364" alt="Screenshot 2023-10-02 at 20 54 01" src="https://github.com/graphql-kit/graphql-voyager/assets/1659414/64ce9132-d468-489e-9dc2-8ce5b52a0448">
