### PR TITLE
Add keyboard shortcut ("/" key) to focus search input

### DIFF
--- a/src/components/doc-explorer/DocExplorer.tsx
+++ b/src/components/doc-explorer/DocExplorer.tsx
@@ -135,7 +135,7 @@ export default class DocExplorer extends Component<
       <div className="type-doc" key={navStack.length}>
         {renderNavigation(previousNav, currentNav)}
         <SearchBox
-          placeholder={`Search ${name}...`}
+          placeholder={`Search ${name}... [ / ]`}
           value={currentNav.searchValue}
           onSearch={this.handleSearch}
         />

--- a/src/components/utils/SearchBox.tsx
+++ b/src/components/utils/SearchBox.tsx
@@ -3,7 +3,9 @@ import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Input from '@mui/material/Input';
 import InputAdornment from '@mui/material/InputAdornment';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import { useFocusInputWithHotkey } from '../../utils/useFocusInputWithHotkey';
 
 interface SearchBoxProps {
   placeholder: string;
@@ -11,14 +13,20 @@ interface SearchBoxProps {
   onSearch: (value: string) => void;
 }
 
+const SEARCH_FOCUS_KEY = '/';
+
 export default function SearchBox(props: SearchBoxProps) {
   const [value, setValue] = useState(props.value ?? '');
   const { placeholder, onSearch } = props;
+
+  const inputRef = useRef<HTMLInputElement>();
 
   useEffect(() => {
     const timeout = setTimeout(() => onSearch(value), 200);
     return () => clearTimeout(timeout);
   }, [onSearch, value]);
+
+  useFocusInputWithHotkey(inputRef.current, SEARCH_FOCUS_KEY);
 
   return (
     <Box paddingLeft={2} paddingRight={2}>
@@ -27,6 +35,7 @@ export default function SearchBox(props: SearchBoxProps) {
         placeholder={placeholder}
         value={value}
         onChange={(event) => setValue(event.target.value)}
+        inputRef={inputRef}
         type="text"
         className="search-box"
         endAdornment={

--- a/src/utils/useFocusInputWithHotkey.ts
+++ b/src/utils/useFocusInputWithHotkey.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+
+import { useOnKeydown } from './useOnKeydown';
+
+export function useFocusInputWithHotkey(
+  target: HTMLInputElement | undefined,
+  key: string,
+) {
+  const keydownHandler = useCallback(
+    (keyboardEvent: KeyboardEvent) => {
+      if (target && !isActiveElementTypable()) {
+        target.focus();
+        keyboardEvent.preventDefault();
+      }
+    },
+    [target],
+  );
+
+  useOnKeydown(key, keydownHandler);
+}
+
+function isActiveElementTypable() {
+  const activeElement = document.activeElement;
+
+  const typableElements = [
+    HTMLInputElement,
+    HTMLTextAreaElement,
+    HTMLSelectElement,
+    HTMLDataListElement,
+    HTMLFieldSetElement,
+  ];
+
+  return (
+    typableElements.some((type) => activeElement instanceof type) ||
+    activeElement?.hasAttribute('contentEditable')
+  );
+}

--- a/src/utils/useOnKeydown.ts
+++ b/src/utils/useOnKeydown.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect } from 'react';
+
+export function useOnKeydown(
+  key: string,
+  callback: (keyboardEvent: KeyboardEvent) => void,
+) {
+  const keydownHandler = useCallback(
+    (keyboardEvent: KeyboardEvent) => {
+      if (keyboardEvent.key === key) {
+        callback(keyboardEvent);
+      }
+    },
+    [key, callback],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', keydownHandler);
+
+    return () => {
+      window.removeEventListener('keydown', keydownHandler);
+    };
+  }, [keydownHandler]);
+}


### PR DESCRIPTION
## Overview

This pull request adds a keyboard shortcut ("/" key) functionality in GraphQL Voyager, enabling users to focus on the search input. This enhancement aims to improve accessibility and empower users to search without relying on mouse interactions.

![Peek 2024-01-05 21-20](https://github.com/graphql-kit/graphql-voyager/assets/38534411/b0944f12-fa0c-4c08-b933-d48a42b8ccd5)

