### PR TITLE
fix: using await in the html file for the hapi middleware

### DIFF
--- a/src/middleware/render-voyager-page.ts
+++ b/src/middleware/render-voyager-page.ts
@@ -38,24 +38,29 @@ export default function renderVoyagerPage(options: MiddlewareOptions) {
     <h1 style="text-align: center; color: #5d7e86;"> Loading... </h1>
   </main>
   <script type="module">
-    window.addEventListener('load', async function(event) {
-      const response = await fetch('${endpointUrl}', {
+    window.addEventListener('load', async function (event) {
+      fetch('${endpointUrl}', {
         method: 'post',
-        headers: Object.assign({}, {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-        }, ${headersJS}),
+        headers: Object.assign(
+          {},
+          {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+          ${headersJS}
+        ),
         body: JSON.stringify({
           query: GraphQLVoyager.voyagerIntrospectionQuery,
         }),
         credentials: 'include',
-      });
-      const introspection = await response.json();
-
-      GraphQLVoyager.renderVoyager(document.getElementById('voyager'), {
-        introspection,
-        displayOptions: ${JSON.stringify(displayOptions)},
-      });
+      })
+        .then((response) => response.json())
+        .then((introspection) => {
+          GraphQLVoyager.renderVoyager(document.getElementById('voyager'), {
+            introspection,
+            displayOptions: ${JSON.stringify(displayOptions)},
+          })
+        })
     })
   </script>
 </body>

--- a/src/middleware/render-voyager-page.ts
+++ b/src/middleware/render-voyager-page.ts
@@ -38,7 +38,7 @@ export default function renderVoyagerPage(options: MiddlewareOptions) {
     <h1 style="text-align: center; color: #5d7e86;"> Loading... </h1>
   </main>
   <script type="module">
-    window.addEventListener('load', async function (event) {
+    window.addEventListener('load', function (event) {
       fetch('${endpointUrl}', {
         method: 'post',
         headers: Object.assign(


### PR DESCRIPTION
Hello, thank you for this project it's impressive :) 


Tried to use it out of curiosity and I noticed an issue with the HTML file that gets generated from [src/middleware/render-voyager-page.ts](https://github.com/graphql-kit/graphql-voyager/blob/main/src/middleware/render-voyager-page.ts).

The issue is that it's using [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) which breaks the browser:

<img width="1123" alt="Screenshot 2024-01-08 at 20 58 45" src="https://github.com/graphql-kit/graphql-voyager/assets/38977667/6b000736-1f92-4d2f-b37d-825b0af5e6b8">

<img width="673" alt="Screenshot 2024-01-08 at 20 58 56" src="https://github.com/graphql-kit/graphql-voyager/assets/38977667/10102318-1a92-40b5-8341-8354d33efe49">



We shouldn't be using await, so I changed the file to include this:


```js
window.addEventListener('load', async function (event) {
  fetch('${endpointUrl}', {
    method: 'post',
    headers: Object.assign(
      {},
      {
        Accept: 'application/json',
        'Content-Type': 'application/json',
      },
      `${headersJS}`
    ),
    body: JSON.stringify({
      query: GraphQLVoyager.voyagerIntrospectionQuery,
    }),
    credentials: 'include',
  })
    .then((response) => response.json())
    .then((introspection) => {
      GraphQLVoyager.renderVoyager(document.getElementById('voyager'), {
        introspection,
        displayOptions: `${JSON.stringify(displayOptions)}`,
      })
    })
})
```
I tested this locally with Hapi, following [this](https://github.com/graphql-kit/graphql-voyager?tab=readme-ov-file#hapi)



Thanks!