### PR TITLE
fix for docker build on macos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./worker/Dockerfile
     volumes:
       - ./worker:/home/worker:ro
-      - ./worker-dist:/home/worker-dist
+      - ./worker-dist/:/home/worker-dist/
     stdin_open: true
     tty: true
   serve-webpack-example:


### PR DESCRIPTION
closes #438

somehow docker build is broken on macos, such a small change will fix it

---

ps: having the same issue as [here](https://github.com/graphql-kit/graphql-voyager/pull/437#issuecomment-2566886081)